### PR TITLE
fix: adds np.random.seed(0) to test_preprocessing.py to ensure determ…

### DIFF
--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -24,6 +24,8 @@ from sagemaker_sklearn_extension.preprocessing import (
     quantile_transform_nonrandom,
 )
 
+np.random.seed(0)
+
 X_zeros = np.zeros((10, 10))
 X_extreme_vals = np.array(
     [


### PR DESCRIPTION
…inistic behavior

*Description of changes:*
`test_log_extreme_value_transformer` uses numpy arrays generated by `np.random`. The array `5 * np.random.random((100, 1)) + 20` is not supposed to have extreme values as defined by `LogExtremeValuesTransformer(threshold_std=2.0)`. However, the use of np.random makes this test indeterministic. For example, with `np.seed(69)` the array has extreme values and the test fails. The addition of `np.random.seed(0)` ensures deterministic behavior in this test.
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
