### PR TITLE
Adding RobustOrdinalEncoder

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/__init__.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/__init__.py
@@ -21,18 +21,20 @@ from .data import QuadraticFeatures
 from .data import RobustStandardScaler
 from .encoders import NALabelEncoder
 from .encoders import RobustLabelEncoder
+from .encoders import RobustOrdinalEncoder
 from .encoders import ThresholdOneHotEncoder
-
 
 __all__ = [
     "BaseExtremeValueTransformer",
     "LogExtremeValuesTransformer",
     "NALabelEncoder",
+    "RobustOrdinalEncoder",
     "QuadraticFeatures",
     "QuantileExtremeValuesTransformer",
     "ThresholdOneHotEncoder",
     "RemoveConstantColumnsTransformer",
     "RobustLabelEncoder",
+    "RobustOrdinalEncoder",
     "RobustStandardScaler",
     "log_transform",
     "quantile_transform_nonrandom",


### PR DESCRIPTION
RobustOrdinalEncoder acts like an sklearn OrdinalEncoder, but does not throw an exception when encountering an
unobserved value. Instead, it assigns it to the integer num_values. For example, if during fit we observe two
values 'Cat', 'Dog', but in transform we observe 'Elephant' and 'Horse'. Both will be encoded as 2.
In the inverse transform the mapping of unknown values is converted to None. Notice that this will cause the array
type to be 'object'. This is consistent with the behaviour of sklearn's OneHotEncoder.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
