### PR TITLE
change: update ci deployment credentials

### DIFF
--- a/ci/buildspec-deploy.yml
+++ b/ci/buildspec-deploy.yml
@@ -4,8 +4,8 @@ phases:
   build:
     commands:
       - PACKAGE_FILE="$CODEBUILD_SRC_DIR_ARTIFACT_1/sagemaker-scikit-learn-extension-*.tar.gz"
-      - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/test/user --query SecretString --output text)
-      - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/test/password --query SecretString --output text)
+      - PYPI_USER=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/user --query SecretString --output text)
+      - PYPI_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /codebuild/pypi/password --query SecretString --output text)
 
       - echo 'md5sum of python package:'
       - md5sum $PACKAGE_FILE


### PR DESCRIPTION
*Description of changes:*
*  update ci deployment credentials to use pypi and not test pypi

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
