### PR TITLE
fix: Specify mlio version 0.2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,14 +16,14 @@ To install,
     # install from pip
     pip install sagemaker-scikit-learn-extension
 
-In order to use the I/O functionalies in the :code:`sagemaker_sklearn_extension.externals` module, you will also need to install the :code:`mlio` package via conda. The :code:`mlio` package is only available through conda at the moment.
+In order to use the I/O functionalies in the :code:`sagemaker_sklearn_extension.externals` module, you will also need to install the :code:`mlio` version 0.2.7 package via conda. The :code:`mlio` package is only available through conda at the moment.
 
 To install :code:`mlio`,
 
 ::
 
     # install mlio
-    conda install -c mlio -c conda-forge mlio-py
+    conda install -c mlio -c conda-forge mlio-py==0.2.7
 
 You can also install from source by cloning this repository and running a ``pip install`` command in the root directory of the repository:
 
@@ -77,7 +77,7 @@ You can install the libraries needed to run the tests by running :code:`pip inst
 
 For unit tests, tox will use pytest to run the unit tests in a Python 3.7 interpreter. tox will also run flake8 and pylint for style checks.
 
-conda is needed because of the dependency on mlio.
+conda is needed because of the dependency on mlio 0.2.7.
 
 To run the tests with tox, run:
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
     -r{toxinidir}/requirements.txt
     .[test]
 conda_deps =
-    mlio-py
+    mlio-py==0.2.7
 conda_channels =
     conda-forge
     mlio


### PR DESCRIPTION
*Issue #, if available:*
`mlio` was recently upgraded to `0.3.X` which introduced breaking API changes. See https://github.com/aws/sagemaker-scikit-learn-extension/issues/9

*Description of changes:*
This PR specifies the dependency of `mlio` to `0.2.7` (latest stable version of `0.2.X`).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
