### PR TITLE
fix: fix for MemoryError in ThresholdOneHotEncoder

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -122,7 +122,7 @@ class ThresholdOneHotEncoder(OneHotEncoder):
 
         for j in range(n_features):
             # get unique values and their counts
-            items, counts = np.unique([row[j] for row in X], return_counts=True)
+            items, counts = np.unique([X[:, j]], return_counts=True)
 
             # add items that appear more than threshold times
             self.categories_[j] = items[counts >= threshold].astype("O")


### PR DESCRIPTION
`ThresholdOneHotEncoder` uses `np.unique` to calculate the frequency of each value in a column. Previously, data was being copied causing unnecessary usage of memory. This change should reduce memory usage by `ThresholdOneHotEncoder`

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
