### PR TITLE
fix: libprotobuf==3.11.4 is not backwards compatible, specify tox version for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ deps =
     .[test]
 conda_deps =
     mlio-py==0.2.7
+    libprotobuf==3.11.0
 conda_channels =
     conda-forge
     mlio


### PR DESCRIPTION
*Description of changes:*
* mlio is broken because libprotobuf released [3.11.4](https://github.com/conda-forge/protobuf-feedstock/commit/3b9196fba32aea80b950e49e6c82429e7ad85368) which is not compatible with other versions of 3.11.X (consumed by mlio)
* This release caused our build systems, sanity checks, and local runs of tox to fail 
* This change fixes the version of libprotobuf to 3.11.0 (confirmed with @cbalioglu to work)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
