### PR TITLE
Fix a minor bug in ThresholdOneHotEncoder by overloading the buggy me…

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -153,6 +153,20 @@ class ThresholdOneHotEncoder(OneHotEncoder):
 
         return self
 
+    def fit_transform(self, X, y=None):
+        # This method is overloaded here in order to fix a minor bug in OneHotEncoder. See the last line of this method
+        self._validate_keywords()
+
+        self._handle_deprecations(X)
+
+        if self._legacy_mode:
+            return super()._transform_selected(
+                X, self._legacy_fit_transform, self.dtype,
+                self._categorical_features, copy=True)
+        else:
+            # The y was added to fit. In OneHotEncoder the next line is: return self.fit(X).transform(X)
+            return self.fit(X, y).transform(X)
+
     def _more_tags(self):
         return {"X_types": ["categorical"]}
 


### PR DESCRIPTION
Fix a minor bug in ThresholdOneHotEncoder by overloading the buggy method from OneHotEncoder and fixing it

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
