### PR TITLE
feature: changed the behavior of OrdinalEncoder for unseen values

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -436,8 +436,8 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
     The input should be a 2D, array-like input of categorical features. Each column of categorical features will be
     converted to ordinal integers. For a given column of n unique values, seen values will be mapped to integers 0 to
-    n-1 and unseen values will be mapped to integer n. An unseen value is a value that was passed in during the
-    transform step, but not present in the fit step input.
+    n-1 and unseen values will be mapped to np.nan (or to the integer n when unknown_as_nan is false). An unseen value
+    is a value that was passed in during the transform step, but not present in the fit step input.
     This encoder supports inverse_transform, transforming ordinal integers back into categorical features. Unknown
     integers are transformed to None.
 
@@ -458,6 +458,11 @@ class RobustOrdinalEncoder(OrdinalEncoder):
     dtype : number type, default np.float32
         Desired dtype of output.
 
+    unknown_as_nan : boolean, default True
+        When unknown_as_nan is true, unknown values are transformed to np.nan
+        When unknown_as_nan is false, unknown values are transformed to n, where n-1 is the last category
+
+
     Attributes
     ----------
     categories_ : list of arrays
@@ -471,7 +476,7 @@ class RobustOrdinalEncoder(OrdinalEncoder):
     values per feature and transform the data to an ordinal encoding.
 
     >>> from sagemaker_sklearn_extension.preprocessing import RobustOrdinalEncoder
-    >>> enc = RobustOrdinalEncoder()
+    >>> enc = RobustOrdinalEncoder(unknown_as_nan=False)
     >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
     >>> enc.fit(X)
     RobustOrdinalEncoder(categories='auto', dtype=<class 'numpy.float32'>)
@@ -491,12 +496,25 @@ class RobustOrdinalEncoder(OrdinalEncoder):
            ['Female', 2],
            [None, None]], dtype=object)
 
+    >>> enc = RobustOrdinalEncoder()
+    >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
+    >>> enc.fit(X)
+    RobustOrdinalEncoder(categories='auto', dtype=<class 'numpy.float32'>)
+    >>> enc.transform([['Female', 3], ['Male', 1], ['Other', 15]])
+    array([[0., 2.],
+           [1., 0.],
+           [np.nan, np.nan]], dtype=float32)
+    >>> enc.inverse_transform([[1, 0], [0, 1], [np.nan, np.nan]])
+    array([['Male', 1],
+           ['Female', 2],
+           [None, None]], dtype=object)
     """
 
-    def __init__(self, categories="auto", dtype=np.float32):
+    def __init__(self, categories="auto", dtype=np.float32, unknown_as_nan=True):
         super(RobustOrdinalEncoder, self).__init__(categories, dtype)
         self.categories = categories
         self.dtype = dtype
+        self.unknown_as_nan = unknown_as_nan
 
     def fit(self, X, y=None):
         """Fit the RobustOrdinalEncoder to X.
@@ -532,13 +550,19 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
         """
         X_int, X_mask = self._transform(X, handle_unknown="unknown")
-        # assign the unknowns an integer indicating they are unknown. The largest integer is always reserved for
-        # unknowns
-        for col in range(X_int.shape[1]):
-            mask = X_mask[:, col]
-            X_int[~mask, col] = self.categories_[col].shape[0]
+        if self.unknown_as_nan:
+            # assign the unknowns np.nan
+            X_int = X_int.astype(self.dtype, copy=False)
+            X_int[~X_mask] = np.nan
+        else:
+            # assign the unknowns an integer indicating they are unknown. The largest integer is always reserved for
+            # unknowns
+            for col in range(X_int.shape[1]):
+                mask = X_mask[:, col]
+                X_int[~mask, col] = self.categories_[col].shape[0]
+            X_int = X_int.astype(self.dtype, copy=False)
 
-        return X_int.astype(self.dtype, copy=False)
+        return X_int
 
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
@@ -562,7 +586,7 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
         """
         check_is_fitted(self, "categories_")
-        X = check_array(X, dtype="numeric")
+        X = check_array(X, dtype="numeric", force_all_finite="allow-nan" if self.unknown_as_nan else True)
 
         n_samples, _ = X.shape
         n_features = len(self.categories_)
@@ -579,7 +603,7 @@ class RobustOrdinalEncoder(OrdinalEncoder):
         found_unknown = {}
         for i in range(n_features):
             labels = X[:, i].astype("int64", copy=False)
-            known_mask = labels != self.categories_[i].shape[0]
+            known_mask = np.isfinite(X[:, i]) if self.unknown_as_nan else (labels != self.categories_[i].shape[0])
             labels *= known_mask
             X_tr[:, i] = self.categories_[i][labels]
             if not np.all(known_mask):

--- a/test/test_preprocessing_encoders.py
+++ b/test/test_preprocessing_encoders.py
@@ -211,22 +211,27 @@ def test_robust_ordinal_encoding_categories():
 
 
 def test_robust_ordinal_encoding_transform():
-    encoder = RobustOrdinalEncoder()
-    encoder.fit(ordinal_data)
-    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
-    encoded = encoder.transform(test_data)
-    assert all(list((encoded[:-1] < 3).reshape((-1,))))
-    assert all(list(encoded[-1] == 3))
+    for unknown_as_nan in [True, False]:
+        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+        encoder.fit(ordinal_data)
+        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
+        encoded = encoder.transform(test_data)
+        assert all(list((encoded[:-1] < 3).reshape((-1,))))
+        if unknown_as_nan:
+            assert all(list(np.isnan(encoded[-1])))
+        else:
+            assert all(list(encoded[-1] == 3))
 
 
 def test_robust_ordinal_encoding_inverse_transform():
-    encoder = RobustOrdinalEncoder()
-    encoder.fit(ordinal_data)
-    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
-    encoded = encoder.transform(test_data)
-    reverse = encoder.inverse_transform(encoded)
-    assert np.array_equal(ordinal_data, reverse[:-1])
-    assert all([x is None for x in reverse[-1]])
+    for unknown_as_nan in [True, False]:
+        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+        encoder.fit(ordinal_data)
+        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
+        encoded = encoder.transform(test_data)
+        reverse = encoder.inverse_transform(encoded)
+        assert np.array_equal(ordinal_data, reverse[:-1])
+        assert all([x is None for x in reverse[-1]])
 
 
 def test_robust_ordinal_encoding_inverse_transform_floatkeys():


### PR DESCRIPTION
An unseen value is a value that was passed in during the transform step, but not present in the fit step input. Previously, RobustOrdinalEncoder mapped unseen values to the integer n where n is the number of categories. This behavior is changed here to map unseen values to np.nan. The new behavior produce better prediction quality since XGBoost can handle np.nan values. The old behavior is still available by setting unknown_as_nan to False.

For a given column of n unique values, seen values will be mapped to integers 0 to
    n-1 and unseen values will be mapped to integer n. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
