### PR TITLE
feature: OrdinalEncoder can output np.nan instead of n for unseen values

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -436,8 +436,8 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
     The input should be a 2D, array-like input of categorical features. Each column of categorical features will be
     converted to ordinal integers. For a given column of n unique values, seen values will be mapped to integers 0 to
-    n-1 and unseen values will be mapped to integer n. An unseen value is a value that was passed in during the
-    transform step, but not present in the fit step input.
+    n-1 and unseen values will be mapped to the integer n (or to np.nan when unknown_as_nan is True). An unseen value
+    is a value that was passed in during the transform step, but not present in the fit step input.
     This encoder supports inverse_transform, transforming ordinal integers back into categorical features. Unknown
     integers are transformed to None.
 
@@ -457,6 +457,11 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
     dtype : number type, default np.float32
         Desired dtype of output.
+
+    unknown_as_nan : boolean, default False
+        When unknown_as_nan is false, unknown values are transformed to n, where n-1 is the last category
+        When unknown_as_nan is true, unknown values are transformed to np.nan
+
 
     Attributes
     ----------
@@ -493,10 +498,11 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
     """
 
-    def __init__(self, categories="auto", dtype=np.float32):
+    def __init__(self, categories="auto", dtype=np.float32, unknown_as_nan=False):
         super(RobustOrdinalEncoder, self).__init__(categories, dtype)
         self.categories = categories
         self.dtype = dtype
+        self.unknown_as_nan = unknown_as_nan
 
     def fit(self, X, y=None):
         """Fit the RobustOrdinalEncoder to X.
@@ -532,13 +538,19 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
         """
         X_int, X_mask = self._transform(X, handle_unknown="unknown")
-        # assign the unknowns an integer indicating they are unknown. The largest integer is always reserved for
-        # unknowns
-        for col in range(X_int.shape[1]):
-            mask = X_mask[:, col]
-            X_int[~mask, col] = self.categories_[col].shape[0]
+        if self.unknown_as_nan:
+            # assign the unknowns np.nan
+            X_int = X_int.astype(self.dtype, copy=False)
+            X_int[~X_mask] = np.nan
+        else:
+            # assign the unknowns an integer indicating they are unknown. The largest integer is always reserved for
+            # unknowns
+            for col in range(X_int.shape[1]):
+                mask = X_mask[:, col]
+                X_int[~mask, col] = self.categories_[col].shape[0]
+            X_int = X_int.astype(self.dtype, copy=False)
 
-        return X_int.astype(self.dtype, copy=False)
+        return X_int
 
     def inverse_transform(self, X):
         """Convert the data back to the original representation.
@@ -562,7 +574,7 @@ class RobustOrdinalEncoder(OrdinalEncoder):
 
         """
         check_is_fitted(self, "categories_")
-        X = check_array(X, dtype="numeric")
+        X = check_array(X, dtype="numeric", force_all_finite="allow-nan" if self.unknown_as_nan else True)
 
         n_samples, _ = X.shape
         n_features = len(self.categories_)
@@ -579,7 +591,7 @@ class RobustOrdinalEncoder(OrdinalEncoder):
         found_unknown = {}
         for i in range(n_features):
             labels = X[:, i].astype("int64", copy=False)
-            known_mask = labels != self.categories_[i].shape[0]
+            known_mask = np.isfinite(X[:, i]) if self.unknown_as_nan else (labels != self.categories_[i].shape[0])
             labels *= known_mask
             X_tr[:, i] = self.categories_[i][labels]
             if not np.all(known_mask):

--- a/test/test_preprocessing_encoders.py
+++ b/test/test_preprocessing_encoders.py
@@ -211,22 +211,27 @@ def test_robust_ordinal_encoding_categories():
 
 
 def test_robust_ordinal_encoding_transform():
-    encoder = RobustOrdinalEncoder()
-    encoder.fit(ordinal_data)
-    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
-    encoded = encoder.transform(test_data)
-    assert all(list((encoded[:-1] < 3).reshape((-1,))))
-    assert all(list(encoded[-1] == 3))
+    for unknown_as_nan in [True, False]:
+        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+        encoder.fit(ordinal_data)
+        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, np.nan]])], axis=0)
+        encoded = encoder.transform(test_data)
+        assert all(list((encoded[:-1] < 3).reshape((-1,))))
+        if unknown_as_nan:
+            assert all(list(np.isnan(encoded[-1])))
+        else:
+            assert all(list(encoded[-1] == 3))
 
 
 def test_robust_ordinal_encoding_inverse_transform():
-    encoder = RobustOrdinalEncoder()
-    encoder.fit(ordinal_data)
-    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
-    encoded = encoder.transform(test_data)
-    reverse = encoder.inverse_transform(encoded)
-    assert np.array_equal(ordinal_data, reverse[:-1])
-    assert all([x is None for x in reverse[-1]])
+    for unknown_as_nan in [True, False]:
+        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+        encoder.fit(ordinal_data)
+        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
+        encoded = encoder.transform(test_data)
+        reverse = encoder.inverse_transform(encoded)
+        assert np.array_equal(ordinal_data, reverse[:-1])
+        assert all([x is None for x in reverse[-1]])
 
 
 def test_robust_ordinal_encoding_inverse_transform_floatkeys():

--- a/test/test_preprocessing_encoders.py
+++ b/test/test_preprocessing_encoders.py
@@ -210,28 +210,28 @@ def test_robust_ordinal_encoding_categories():
         assert set(cat) == set(ordinal_expected_categories_[i])
 
 
-def test_robust_ordinal_encoding_transform():
-    for unknown_as_nan in [True, False]:
-        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
-        encoder.fit(ordinal_data)
-        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, np.nan]])], axis=0)
-        encoded = encoder.transform(test_data)
-        assert all(list((encoded[:-1] < 3).reshape((-1,))))
-        if unknown_as_nan:
-            assert all(list(np.isnan(encoded[-1])))
-        else:
-            assert all(list(encoded[-1] == 3))
+@pytest.mark.parametrize("unknown_as_nan", (True, False))
+def test_robust_ordinal_encoding_transform(unknown_as_nan):
+    encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+    encoder.fit(ordinal_data)
+    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, np.nan]])], axis=0)
+    encoded = encoder.transform(test_data)
+    assert all(list((encoded[:-1] < 3).reshape((-1,))))
+    if unknown_as_nan:
+        assert all(list(np.isnan(encoded[-1])))
+    else:
+        assert all(list(encoded[-1] == 3))
 
 
-def test_robust_ordinal_encoding_inverse_transform():
-    for unknown_as_nan in [True, False]:
-        encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
-        encoder.fit(ordinal_data)
-        test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
-        encoded = encoder.transform(test_data)
-        reverse = encoder.inverse_transform(encoded)
-        assert np.array_equal(ordinal_data, reverse[:-1])
-        assert all([x is None for x in reverse[-1]])
+@pytest.mark.parametrize("unknown_as_nan", (True, False))
+def test_robust_ordinal_encoding_inverse_transform(unknown_as_nan):
+    encoder = RobustOrdinalEncoder(unknown_as_nan=unknown_as_nan)
+    encoder.fit(ordinal_data)
+    test_data = np.concatenate([ordinal_data, np.array([["waffle", 1213, None]])], axis=0)
+    encoded = encoder.transform(test_data)
+    reverse = encoder.inverse_transform(encoded)
+    assert np.array_equal(ordinal_data, reverse[:-1])
+    assert all([x is None for x in reverse[-1]])
 
 
 def test_robust_ordinal_encoding_inverse_transform_floatkeys():


### PR DESCRIPTION
An unseen value is a value that was passed in during the transform step, but was not present in the fit step input. The default behavior of `RobustOrdinalEncoder` is to map unseen values to the integer `n` where `n` is the number of categories. This new feature (enabled by setting the flag `unknown_as_nan` to `True`) maps unseen values to `np.nan`. The new behavior produces better prediction quality since XGBoost can handle `np.nan` values

### tests
- added a test for the new feature
- added a test for `np.nan` as input for `transform()`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
