### PR TITLE
feature: adds a `get_classes` method to `RobustLabelEncoder`

### DIFF
--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -233,20 +233,29 @@ class RobustLabelEncoder(LabelEncoder):
     fill_label_value : str (default = '<unseen_label>')
         Replacement value for unseen encoded labels during ``inverse_transform``.
 
+    include_unseen_class: boolean (default = False)
+        Whether or not ``fill_label_value`` should be included as a class.
+
     Attributes
     ----------
     classes_ : array of shape (n_classes,)
-        Holds the label for each class.
+        Holds the label for each class that is seen when the encoder is ``fit``.
     """
 
     def __init__(
-        self, labels=None, fill_unseen_labels=True, fill_encoded_label_value=None, fill_label_value="<unseen_label>"
+        self,
+        labels=None,
+        fill_unseen_labels=True,
+        fill_encoded_label_value=None,
+        fill_label_value="<unseen_label>",
+        include_unseen_class=False,
     ):
         super().__init__()
         self.labels = labels
         self.fill_unseen_labels = fill_unseen_labels
         self.fill_encoded_label_value = fill_encoded_label_value
         self.fill_label_value = fill_label_value
+        self.include_unseen_class = include_unseen_class
 
     def fit(self, y):
         """Fit label encoder.
@@ -360,6 +369,19 @@ class RobustLabelEncoder(LabelEncoder):
 
         y_decoded = [self.classes_[idx] if idx in labels else self.fill_label_value for idx in y]
         return y_decoded
+
+    def get_classes(self):
+        """Returns the values of the unencoded classes.
+        If ``self.include_unseen_class`` is ``True`` include ``self.fill_label_value`` as a class.
+
+        Returns
+        -------
+        classes : array of shape (n_classes,)
+        """
+        if not self.include_unseen_class or not self.fill_unseen_labels:
+            return self.classes_
+
+        return self.classes_ + [self.fill_label_value]
 
 
 class NALabelEncoder(BaseEstimator, TransformerMixin):

--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -378,10 +378,10 @@ class RobustLabelEncoder(LabelEncoder):
         -------
         classes : array of shape (n_classes,)
         """
-        if not self.include_unseen_class or not self.fill_unseen_labels:
-            return self.classes_
+        if self.include_unseen_class and self.fill_unseen_labels:
+            return np.append(self.classes_, [self.fill_label_value])
 
-        return np.append(self.classes_, [self.fill_label_value])
+        return self.classes_
 
 
 class NALabelEncoder(BaseEstimator, TransformerMixin):

--- a/src/sagemaker_sklearn_extension/preprocessing/encoders.py
+++ b/src/sagemaker_sklearn_extension/preprocessing/encoders.py
@@ -381,7 +381,7 @@ class RobustLabelEncoder(LabelEncoder):
         if not self.include_unseen_class or not self.fill_unseen_labels:
             return self.classes_
 
-        return self.classes_ + [self.fill_label_value]
+        return np.append(self.classes_, [self.fill_label_value])
 
 
 class NALabelEncoder(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
If there are unseen labels the `fill_label_value` does not appear in the `self.classes_` attribute. With this change, `get_classes` can be used with `include_unseen_class` tag of the constructor to return all of the class labels, including the label for the unseen values.

*Issue #, if available:*

*Description of changes:*
If there are unseen labels the `fill_label_value` does not appear in the `self.classes_` attribute. With this change, `get_classes` can be used with `include_unseen_class` tag of the constructor to return all of the class labels, including the label for the unseen values.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
