### PR TITLE
feature: transformers for time series

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,9 @@ Overview of Submodules
    * :code:`read_csv_data` reads comma separated data and returns a numpy array (uses mlio)
 * :code:`sagemaker_sklearn_extension.feature_extraction.date_time`
    * :code:`DateTimeVectorizer` convert datetime objects or strings into numeric features
+* :code:`sagemaker_sklearn_extension.feature_extraction.sequences`
+   * :code:`TSFlattener` convert strings of sequences into numeric features
+   * :code:`TSFreshFeatureExtractor` compute row-wise time series features from a numpy array (uses tsfresh)
 * :code:`sagemaker_sklearn_extension.feature_extraction.text`
    * :code:`MultiColumnTfidfVectorizer` convert collections of raw documents to a matrix of TF-IDF features
 * :code:`sagemaker_sklearn_extension.impute`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy>=1.16.4
 psutil
 scikit-learn==0.23.2
 python-dateutil==2.8.0
+pandas==1.2.4
+tsfresh==0.18.0

--- a/src/sagemaker_sklearn_extension/feature_extraction/__init__.py
+++ b/src/sagemaker_sklearn_extension/feature_extraction/__init__.py
@@ -18,8 +18,8 @@ to extract features from text. This module is based on the
 :mod:`sklearn.feature_extraction` module.
 """
 
-from sagemaker_sklearn_extension.feature_extraction import date_time
-from sagemaker_sklearn_extension.feature_extraction import sequences
-from sagemaker_sklearn_extension.feature_extraction import text
+from . import date_time
+from . import sequences
+from . import text
 
 __all__ = ["date_time", "sequences", "text"]

--- a/src/sagemaker_sklearn_extension/feature_extraction/__init__.py
+++ b/src/sagemaker_sklearn_extension/feature_extraction/__init__.py
@@ -18,7 +18,8 @@ to extract features from text. This module is based on the
 :mod:`sklearn.feature_extraction` module.
 """
 
-from . import date_time
-from . import text
+from sagemaker_sklearn_extension.feature_extraction import date_time
+from sagemaker_sklearn_extension.feature_extraction import sequences
+from sagemaker_sklearn_extension.feature_extraction import text
 
-__all__ = ["date_time", "text"]
+__all__ = ["date_time", "sequences", "text"]

--- a/src/sagemaker_sklearn_extension/feature_extraction/sequences.py
+++ b/src/sagemaker_sklearn_extension/feature_extraction/sequences.py
@@ -1,0 +1,193 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#      http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_array, check_is_fitted
+from tsfresh import extract_features
+from tsfresh.feature_extraction import ComprehensiveFCParameters
+from tsfresh.utilities.dataframe_functions import impute
+
+from sagemaker_sklearn_extension.preprocessing.data import RobustStandardScaler
+
+
+class TSFlattener(BaseEstimator, TransformerMixin):
+    """Convert lists of strings of varying length into an np.array.
+
+    The input is a collection of lists of strings, with each string containing a sequence of comma-separate numbers.
+    TSFlattener extracts the numerical values contained in these strings and pads shorter sequences (if any) with NaNs,
+    so that all sequences match the length of the longest sequence. TSFlattener returns a single np.array as output.
+
+    Any missing values (represented either by a NaN, inf or empty string) are converted to np.nans.
+
+    Example:
+    Input = [["1,, 3, 44"],
+             ["11, 111"],
+             ["NaN, , 1, NaN"]]
+    Output = [[1, np.nan, 3, 44],
+              [11, 111, np.nan, np.nan],
+              [np.nan, np.nan, 1, np.nan]
+              ]
+    """
+
+    def fit(self, X, y=None):
+        check_array(X, dtype=None, force_all_finite="allow-nan")
+        return self
+
+    def transform(self, X, y=None):
+        """Extract numerical values from strings of comma-separated numbers and returns an np.array.
+
+        - If some sequences are shorter than the longest sequence, these are padded with np.nans.
+        - Any NaN, inf or empty string is converted to a np.nan.
+
+        Parameters
+        ----------
+        X : lists of strings
+
+        Returns
+        -------
+        X : np.array
+
+        """
+        X = check_array(X, dtype=None, force_all_finite="allow-nan")
+
+        numeric_sequences = []
+        for string_sequence in X:
+            assert len(string_sequence) == 1, (
+                f"TSFlattener can process a single sequence column at a time, "
+                f"but it was given {len(string_sequence)} sequence columns."
+            )
+            numeric_sequence = [float(s) if (s and not s.isspace()) else np.nan for s in string_sequence[0].split(",")]
+            # Convert inf (if any) to np.nan
+            numeric_sequence = [value if (not np.isinf(value)) else np.nan for value in numeric_sequence]
+            numeric_sequences.append(numeric_sequence)
+        # Pad shorter sequences with np.nan to reach the length of the longest sequence
+        max_length = np.max([len(numeric_sequence) for numeric_sequence in numeric_sequences])
+        padded_sequences = []
+        for sequence in numeric_sequences:
+            if len(sequence) < max_length:
+                length_difference = max_length - len(sequence)
+                padding_nans = np.array([np.nan] * length_difference)
+                sequence = np.hstack([sequence, padding_nans])
+            padded_sequences.append(sequence)
+        X = np.array(padded_sequences)
+        return X
+
+    def _more_tags(self):
+        return {"X_types": ["string"], "allow_nan": True}
+
+
+class TSFreshFeatureExtractor(BaseEstimator, TransformerMixin):
+    """Extract features computed by tsfresh from each row of an array and append them to the input
+    array (if augment = True) or return the extracted features alone (if augment = False).
+
+    Examples of these features are the mean, median, kurtosis, and autocorrelation of each sequence. The full list
+    of extracted features can be found at https://tsfresh.readthedocs.io/en/latest/text/list_of_features.html.
+
+    Parameters
+    ----------
+    augment : boolean (default=True):
+        Whether to append the tsfresh features to the original raw data (if True),
+        or output only the extracted tsfresh features (if False)
+
+    interpolation_method : {'linear', 'fill', 'zeroes', None} (default='zeroes')
+        'linear': linear interpolation
+        'fill': forward fill to complete the sequences; then, backfill in case of NaNs at the start of the sequence.
+        'zeroes': pad with zeroes
+         None: no interpolation
+
+    Attributes
+    ----------
+    self.robust_standard_scaler_ : ``sagemaker_sklearn_extension.preprocessing.data.RobustStandardScaler``
+        - `robust_standard_scaler_` is instantiated inside the fit method used for computing the mean and
+        the standard deviation.
+
+    """
+
+    def __init__(self, augment=True, interpolation_method="zeroes"):
+        super().__init__()
+        self.augment = augment
+        self.interpolation_method = interpolation_method
+
+    def fit(self, X, y=None):
+        X = check_array(X, force_all_finite="allow-nan")
+        self._dim = X.shape[1]
+        tsfresh_features, _ = self._extract_tsfresh_features(X)
+        robust_standard_scaler = RobustStandardScaler()
+        robust_standard_scaler.fit(tsfresh_features)
+        self.robust_standard_scaler_ = robust_standard_scaler
+        return self
+
+    def transform(self, X, y=None):
+        X = check_array(X, force_all_finite="allow-nan")
+        check_is_fitted(self, "robust_standard_scaler_")
+        if X.shape[1] != self._dim:
+            raise ValueError(f"The input dimension is {X.shape[1]} instead of the expected {self._dim}")
+        tsfresh_features, X_df = self._extract_tsfresh_features(X)
+        tsfresh_features = pd.DataFrame(self.robust_standard_scaler_.transform(tsfresh_features))
+        if self.augment:
+            # Append the extracted features to the original dataset X, after converting X
+            # from a DataFrame back to a np.array (with missing values imputed)
+            X = X_df.groupby("id").agg(lambda x: x.tolist())[0].to_numpy()
+            X = np.stack(X, axis=0)
+            tsfresh_features = np.hstack((X, tsfresh_features.to_numpy()))
+        return tsfresh_features
+
+    @staticmethod
+    def _impute_ts(X, interpolation_method):
+        """Impute time series missing values by linear interpolation,
+        forward/backward filling, or padding with zeroes.
+        """
+        if interpolation_method == "linear":
+            X[0] = X[0].interpolate(method=interpolation_method, limit_direction="both")
+        elif interpolation_method == "fill":
+            # Forward fill to complete the sequences. Then, backfill in case of NaNs at the start of the sequence.
+            X[0] = X[0].interpolate(method="ffill", axis=0).interpolate(method="bfill", axis=0)
+        elif interpolation_method == "zeroes":
+            X[0] = X[0].fillna(0)
+        else:
+            raise ValueError(
+                f"{interpolation_method} is not a supported interpolation method. Please choose one from "
+                f"the following options: [linear, fill, zeroes]."
+            )
+        return X
+
+    @staticmethod
+    def _convert_to_df(X):
+        """Convert the np.array X into a dataframe compatible with extract_features."""
+        X_df = pd.DataFrame(data=X.astype("float64"))
+        X_df = X_df.stack(dropna=False)  # dropna=True would drop value for all sequences if at least one has a np.nan
+        X_df.index.rename(["id", "time"], inplace=True)
+        X_df = X_df.reset_index()
+        return X_df
+
+    def _interpolate(self, X_df):
+        """Impute missing values through the selected interpolation_method."""
+        if self.interpolation_method is not None:
+            X_df = self._impute_ts(X_df, self.interpolation_method)
+        return X_df
+
+    def _extract_tsfresh_features(self, X):
+        X_df = self._convert_to_df(X)
+        X_df = self._interpolate(X_df)
+        # Extract time series features from the dataframe
+        # Replace all ``NaNs`` and ``infs`` in the extracted features with average/extreme values for that column
+        extraction_settings = ComprehensiveFCParameters()
+        tsfresh_features = extract_features(
+            X_df, default_fc_parameters=extraction_settings, column_id="id", column_sort="time", impute_function=impute
+        )
+        return tsfresh_features, X_df
+
+    def _more_tags(self):
+        return {"allow_nan": True}

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -20,7 +20,7 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from sagemaker_sklearn_extension.feature_extraction.text import MultiColumnTfidfVectorizer
 from sagemaker_sklearn_extension.feature_extraction.date_time import DateTimeVectorizer
-from sagemaker_sklearn_extension.feature_extraction.sequences import TimeSeriesFeatureExtractor
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFeatureExtractor
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFlattener
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFreshFeatureExtractor
 from sagemaker_sklearn_extension.impute import RobustImputer
@@ -52,7 +52,7 @@ from sagemaker_sklearn_extension.preprocessing import WOEEncoder
         RobustStandardScaler(),
         ThresholdOneHotEncoder(),
         WOEEncoder(),
-        TimeSeriesFeatureExtractor(),
+        TSFeatureExtractor(),
         TSFlattener(),
         TSFreshFeatureExtractor(),
     ],

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -20,6 +20,8 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from sagemaker_sklearn_extension.feature_extraction.text import MultiColumnTfidfVectorizer
 from sagemaker_sklearn_extension.feature_extraction.date_time import DateTimeVectorizer
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFlattener
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFreshFeatureExtractor
 from sagemaker_sklearn_extension.impute import RobustImputer
 from sagemaker_sklearn_extension.impute import RobustMissingIndicator
 from sagemaker_sklearn_extension.preprocessing import LogExtremeValuesTransformer
@@ -49,6 +51,8 @@ from sagemaker_sklearn_extension.preprocessing import WOEEncoder
         RobustStandardScaler(),
         ThresholdOneHotEncoder(),
         WOEEncoder(),
+        TSFlattener(),
+        TSFreshFeatureExtractor(),
     ],
 )
 def test_all_estimators(Estimator):

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -20,6 +20,7 @@ from sklearn.utils.estimator_checks import check_estimator
 
 from sagemaker_sklearn_extension.feature_extraction.text import MultiColumnTfidfVectorizer
 from sagemaker_sklearn_extension.feature_extraction.date_time import DateTimeVectorizer
+from sagemaker_sklearn_extension.feature_extraction.sequences import TimeSeriesFeatureExtractor
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFlattener
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFreshFeatureExtractor
 from sagemaker_sklearn_extension.impute import RobustImputer
@@ -51,6 +52,7 @@ from sagemaker_sklearn_extension.preprocessing import WOEEncoder
         RobustStandardScaler(),
         ThresholdOneHotEncoder(),
         WOEEncoder(),
+        TimeSeriesFeatureExtractor(),
         TSFlattener(),
         TSFreshFeatureExtractor(),
     ],

--- a/test/test_sequence_transformer.py
+++ b/test/test_sequence_transformer.py
@@ -1,0 +1,127 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#      http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import numpy as np
+import pytest
+
+from sklearn.utils.testing import assert_array_equal
+
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFlattener
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFreshFeatureExtractor
+
+# To test TSFlattener with and without missing values encoded in different ways
+X_sequence = [["1, 2, 3, 44"], ["11, 12, 14, 111"], ["1, 1, 1, 2"]]
+X_flat = [[1, 2, 3, 44], [11, 12, 14, 111], [1, 1, 1, 2]]
+X_sequence_missing = [["1, NaN, 3, 44"], ["11, 12, NaN, 111"], ["NaN, NaN, 1, NaN"]]
+X_flat_filled = [[1, np.nan, 3, 44], [11, 12, np.nan, 111], [np.nan, np.nan, 1, np.nan]]
+X_sequence_varying_length = [["1"], ["11, 111"], ["2, 3, 1, 4"]]
+X_flat_padded = [[1, np.nan, np.nan, np.nan], [11, 111, np.nan, np.nan], [2, 3, 1, 4]]
+X_sequence_varying_length_missing = [["1"], ["NaN, 111"], ["2, NaN, 1, 4"]]
+X_flat_padded_filled = [[1, np.nan, np.nan, np.nan], [np.nan, 111, np.nan, np.nan], [2, np.nan, 1, 4]]
+X_sequence_gaps = [["1, , 3, 44"], ["11, 12, , 111"], [", , 1, "]]
+X_sequence_variable_gaps = [[" 1,    , 3,   44"], ["11,  12,  , 111"], [",, 1, "]]
+X_flat_gaps_filled = [[1, np.nan, 3, 44], [11, 12, np.nan, 111], [np.nan, np.nan, 1, np.nan]]
+X_sequence_inf = [["1, inf, 3, 44"], ["11, 12, inf, 111"], ["inf, inf, 1, inf"]]
+X_flat_inf = [[1, np.nan, 3, 44], [11, 12, np.nan, 111], [np.nan, np.nan, 1, np.nan]]
+X_sequence_empty = [["1, 2, 3, 44"], [""], ["1, 1, 1, 2"]]
+X_flat_full = [[1, 2, 3, 44], [np.nan, np.nan, np.nan, np.nan], [1, 1, 1, 2]]
+X_multiple_sequences = [["1, 2, 3, 4", "1, 1, 3, 3"], ["11, 12, 14, 11", "10, 1, 1, 2"], ["10, 1, 1, 2", "1, 1, 1, 2"]]
+
+# To test TSFreshFeatureExtractor with and without np.nans
+X_input = np.array([[1, 2, 3], [4, 5, 6], [10, 10, 10]])
+X_transformed = np.array([[1, 2, 3], [4, 5, 6], [10, 10, 10]])
+X_impute = np.array([[np.nan, 2, np.nan], [4, np.nan, 6], [10, np.nan, 10]])
+X_padded = np.array([[0, 2, 0], [4, 0, 6], [10, 0, 10]])
+X_filled = np.array([[2, 2, 2], [4, 4, 6], [10, 10, 10]])
+X_interpolated = np.array([[2, 2, 3], [4, 5, 6], [10, 10, 10]])
+X_with_first_feature = np.array([[1.0, 2.0, 3.0, 44.0], [11.0, 12.0, 14.0, 111.0], [1.0, 1.0, 1.0, 2.0]])
+X_padded_with_first_feature = np.array([[1.0, 0.0, 3.0, 44.0], [11.0, 12.0, 0.0, 111.0], [0.0, 0.0, 1.0, 0.0]])
+
+flattener_error_msg = "TSFlattener can process a single sequence column at a time, but it was given 2 sequence columns."
+tsfresh_error_msg = "The input dimension is 4 instead of the expected 3"
+
+
+@pytest.mark.parametrize(
+    "X, X_expected",
+    [
+        (X_sequence, X_flat),
+        (X_sequence_missing, X_flat_filled),
+        (X_sequence_varying_length, X_flat_padded),
+        (X_sequence_varying_length_missing, X_flat_padded_filled),
+        (X_sequence_gaps, X_flat_gaps_filled),
+        (X_sequence_variable_gaps, X_flat_gaps_filled),
+        (X_sequence_inf, X_flat_inf),
+        (X_sequence_empty, X_flat_full),
+    ],
+)
+def test_flattener(X, X_expected):
+    ts_flattener = TSFlattener()
+    X_observed = ts_flattener.transform(X)
+    assert_array_equal(X_observed, X_expected)
+
+
+def test_flattener_transform_input_error():
+    with pytest.raises(AssertionError, match=flattener_error_msg):
+        ts_flattener = TSFlattener()
+        ts_flattener.transform(X_multiple_sequences)
+
+
+@pytest.mark.parametrize(
+    "X, num_expected_features, augment", [(X_input, 790, True), (X_input, 787, False)],
+)
+def test_tsfresh_feature_dimension(X, num_expected_features, augment):
+    tsfresh_feature_extractor = TSFreshFeatureExtractor(augment=augment)
+    tsfresh_feature_extractor.fit(X_input)
+    X_with_features = tsfresh_feature_extractor.transform(X)
+    num_tsfresh_features = X_with_features.shape[1]
+    assert num_tsfresh_features == num_expected_features
+
+
+@pytest.mark.parametrize(
+    "X, X_expected, augment, interpolation_method",
+    [
+        (X_input, X_input, True, None),
+        (X_impute, X_padded, True, "zeroes"),
+        (X_impute, X_filled, True, "fill"),
+        (X_impute, X_interpolated, True, "linear"),
+    ],
+)
+def test_tsfresh_interpolations(X, X_expected, augment, interpolation_method):
+    tsfresh_feature_extractor = TSFreshFeatureExtractor(augment=augment, interpolation_method=interpolation_method)
+    tsfresh_feature_extractor.fit(X)
+    X_with_features = tsfresh_feature_extractor.transform(X)
+    num_dim = X.shape[1]
+    X_observed = X_with_features[:, :num_dim]
+    assert_array_equal(X_observed, X_expected)
+
+
+def test_tsfresh_transform_dim_error():
+    with pytest.raises(ValueError, match=tsfresh_error_msg):
+        tsfresh_feature_extractor = TSFreshFeatureExtractor()
+        tsfresh_feature_extractor.fit(X_impute)
+        tsfresh_feature_extractor.transform(np.zeros((3, 4)))
+
+
+@pytest.mark.parametrize(
+    "X, X_expected", [(X_sequence, X_with_first_feature), (X_sequence_missing, X_padded_with_first_feature),],
+)
+def test_full_time_series_pipeline(X, X_expected):
+    # Extract sequences from strings
+    ts_flattener = TSFlattener()
+    X_flattened = ts_flattener.transform(X)
+    # Compute tsfresh features
+    tsfresh_feature_extractor = TSFreshFeatureExtractor()
+    tsfresh_feature_extractor.fit(X_flattened)
+    X_with_features = tsfresh_feature_extractor.transform(X_flattened)
+    X_observed = X_with_features[:4, :4]
+    assert_array_equal(X_observed, X_expected)

--- a/test/test_sequence_transformer.py
+++ b/test/test_sequence_transformer.py
@@ -16,7 +16,7 @@ import pytest
 
 from sklearn.utils.testing import assert_array_almost_equal
 
-from sagemaker_sklearn_extension.feature_extraction.sequences import TimeSeriesFeatureExtractor
+from sagemaker_sklearn_extension.feature_extraction.sequences import TSFeatureExtractor
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFlattener
 from sagemaker_sklearn_extension.feature_extraction.sequences import TSFreshFeatureExtractor
 
@@ -111,7 +111,7 @@ def test_flattener_with_truncation(X, X_expected, trim_beginning):
 
 
 def test_flattener_transform_input_error():
-    with pytest.raises(AssertionError, match=flattener_error_msg):
+    with pytest.raises(ValueError, match=flattener_error_msg):
         ts_flattener = TSFlattener()
         ts_flattener.transform(X_multiple_sequences)
 
@@ -194,12 +194,12 @@ def test_full_time_series_pipeline(X, X_expected):
     ts_flattener = TSFlattener()
     X_flattened = ts_flattener.transform(X)
     # Compute tsfresh features
-    tsfresh_feature_extractor = TSFreshFeatureExtractor(extraction_type="all")
+    tsfresh_feature_extractor = TSFreshFeatureExtractor(extraction_type="all", augment=True)
     tsfresh_feature_extractor.fit(X_flattened)
     X_with_features_combined_transformers = tsfresh_feature_extractor.transform(X_flattened)
     X_observed_combined_transformers = X_with_features_combined_transformers[:5, :5]
-    # Repeat the above in a single step with the TimeSeriesFeatureExtractor wrapper
-    time_series_feature_extractor = TimeSeriesFeatureExtractor(extraction_type="all")
+    # Repeat the above in a single step with the TSFeatureExtractor wrapper
+    time_series_feature_extractor = TSFeatureExtractor(extraction_type="all", augment=True)
     X_with_features_time_series_transformer = time_series_feature_extractor.fit_transform(X)
     X_observed_time_series_transformer = X_with_features_time_series_transformer[:5, :5]
     # Compare the two outputs with each other and with the expected result
@@ -213,7 +213,7 @@ def test_full_time_series_pipeline(X, X_expected):
     [(X_multiple_sequences, X_filled_with_first_feature), (X_sequence_missing, X_filled_with_first_feature),],
 )
 def test_time_series_feature_extractor_multiple_columns(X, X_expected):
-    time_series_feature_extractor = TimeSeriesFeatureExtractor(augment=True, extraction_type="all")
+    time_series_feature_extractor = TSFeatureExtractor(augment=True, extraction_type="all")
     X_with_features_time_series_transformer = time_series_feature_extractor.fit_transform(X)
     num_sequence_columns = np.array(X).shape[1]
     # The output is expected to have 787 features (extracted from tsfresh) for each sequence column in the input,


### PR DESCRIPTION
*Description of changes:*

Add transformers that handle sequential data such as time series. Three main estimators are introduced:

1. TSFlattener converts a list of input strings containing sequences of varying length into a list of arrays.
2. TSFreshFeatureExtractor extracts features computed by tsfresh from each input array.
3. TimeSeriesFeatureExtractor applies the two transformers above sequentially to each sequence column in the input.

## Merge Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/CONTRIBUTING.md#committing-your-change)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-scikit-learn-extension/blob/master/README.rst) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
